### PR TITLE
[TASK] made it possible to set default fields for new content element

### DIFF
--- a/Classes/Service/ContentEditableWrapperService.php
+++ b/Classes/Service/ContentEditableWrapperService.php
@@ -115,10 +115,16 @@ class ContentEditableWrapperService
      * @param string $content
      * @return string
      * @param int $colPos
+     * @param array $defaultValues
      * @throws \InvalidArgumentException
      */
-    public function wrapContentWithDropzone(string $table, int $uid, string $content, int $colPos = 0): string
-    {
+    public function wrapContentWithDropzone(
+        string $table,
+        int $uid,
+        string $content,
+        int $colPos = 0,
+        array $defaultValues = []
+    ): string {
         // Check that data is not empty
         if (empty($table)) {
             throw new \InvalidArgumentException('Property "table" can not to be empty!', 1486163430);
@@ -137,7 +143,7 @@ class ContentEditableWrapperService
             $jsFuncOnDrop,
             $jsFuncOnDragover,
             $jsFuncOnDragLeave,
-            $this->renderEditOnClickReturnUrl($this->renderNewUrl($table, (int)$uid, (int)$colPos))
+            $this->renderEditOnClickReturnUrl($this->renderNewUrl($table, (int)$uid, (int)$colPos, $defaultValues))
         );
 
         return $content;
@@ -193,9 +199,10 @@ class ContentEditableWrapperService
      * @param string $table
      * @param int $uid
      * @param int $colPos
+     * @param array $defaultValues
      * @return string
      */
-    public function renderNewUrl(string $table, int $uid = 0, int $colPos = 0): string
+    public function renderNewUrl(string $table, int $uid = 0, int $colPos = 0, array $defaultValues = []): string
     {
         // Default to top of 'page'
         $newId = (int)$GLOBALS['TSFE']->id;
@@ -212,8 +219,12 @@ class ContentEditableWrapperService
         ];
 
         // If there is no any content in drop zone we need to set colPos
-        if ($colPos > 0) {
-            $urlParameters['overrideVals[' . $table . '][colPos]'] = $colPos;
+        if ($colPos !== 0) {
+            $urlParameters['defVals'][$table]['colPos'] = $colPos;
+        }
+        // If there are any fields to set
+        if (!empty($defaultValues)) {
+            $urlParameters['defVals'][$table] = array_merge($urlParameters['defVals'][$table] ?? [], $defaultValues);
         }
 
         $newUrl = BackendUtility::getModuleUrl(

--- a/Documentation/NewContentElements/Index.rst
+++ b/Documentation/NewContentElements/Index.rst
@@ -1,0 +1,52 @@
+.. include:: ../Includes.txt
+
+
+
+.. _new-content-elements:
+
+New Content Elements
+------------
+
+It's possible to add drop zone for new content elements in a custom places. There a special ContentEditableWrapperService.
+
+- Example of usage.
+
+  .. code-block:: typoscript
+
+     page = PAGE
+     page.1001 = USER
+     page.1001 {
+        userFunc = Your\NameSpace\YourWrappingClass->wrapWithDropZone
+     }
+
+- Create your PHP class with user function
+
+  .. code-block:: php
+    namespace Your\NameSpace;
+      class YourWrappingClass {
+        /**
+         * @param  string          Empty string (no content to process)
+         * @param  array           TypoScript configuration
+         */
+        public function wrapWithDropZone($content, $conf)
+        {
+          if (\TYPO3\CMS\Core\Utility\GeneralUtility::_GET('frontend_editing')
+            && \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\FrontendEditing\Service\AccessService::class)->isEnabled()
+          ) {
+            /** @var \TYPO3\CMS\FrontendEditing\Service\ContentEditableWrapperService $wrapperService */
+            $wrapperService = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\FrontendEditing\Service\ContentEditableWrapperService::class);
+
+            $content = $wrapperService->wrapContentWithDropzone(
+              'tt_content', // table name
+              -1, // page uid, pid
+              $content,
+              0, // colPos
+              // additional fields if needed
+              [
+                'subheader' => 'default subheader'
+              ]
+            );
+          }
+          return $content;
+        }
+      }

--- a/Documentation/NewContentElements/Index.rst
+++ b/Documentation/NewContentElements/Index.rst
@@ -7,7 +7,7 @@
 New Content Elements
 ------------
 
-It's possible to add drop zone for new content elements in a custom places. There a special ContentEditableWrapperService.
+It's possible to add drop zones for new content elements in a custom content elements. This is done by the class called ContentEditableWrapperService.
 
 - Example of usage.
 


### PR DESCRIPTION
With default values it's possible to predefine content element fields. Use in case when you need to add a drop zone with custom user function.