### PR TITLE
[BUGFIX] set UID of root page when ?id= missing

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -340,6 +340,11 @@ class FrontendEditingInitializationHook
                         1227834741
                     );
                 }
+                // Check if ID is set
+                if (!$contentController->id) {
+                    $contentController->id = $this->typoScriptFrontendController->id;
+                }
+
                 $hookObject->manipulateWizardItems($wizardItems, $contentController);
             }
         }


### PR DESCRIPTION
When GET parameter ID is not set , property ID is missing for wizard items hook