### PR TITLE
[BUGFIX] fixed JS error when setting link with CKEditor in modal iframe

### DIFF
--- a/Documentation/Development/Hooks/Index.rst
+++ b/Documentation/Development/Hooks/Index.rst
@@ -23,7 +23,7 @@ This is used in case you need to influence on a process of wrapping with drop zo
 
 - Create hook class to control drop zone wrapping process
 
-    .. code-block:: php
+  .. code-block:: php
 
     <?php
 

--- a/Resources/Public/JavaScript/Editor.js
+++ b/Resources/Public/JavaScript/Editor.js
@@ -89,8 +89,21 @@ define(['jquery', 'ckeditor', 'ckeditor-jquery-adapter'], function ($, CKEDITOR)
 						content: that.data('edit-url'),
 						size: Modal.sizes.large,
 						callback: function(currentModal) {
+							// Hide header of modal
 							currentModal.find('.modal-header').hide();
+
+							// Simulate BE environment with correct CKEditor instance for  RteLinkBrowser
+							currentModal.find(Modal.identifiers.iframe).on('load',function() {
+								top.TYPO3.Backend = top.TYPO3.Backend || {};
+								top.TYPO3.Backend.ContentContainer = {
+									get: function () {
+										return currentModal.find(Modal.identifiers.iframe).get(0).contentWindow;
+									}
+								};
+							});
+
 							currentModal.on('hidden.bs.modal', function (e) {
+								delete top.TYPO3.Backend;
 								F.refreshIframe();
 							});
 						}


### PR DESCRIPTION
Set up link (both internal and external) in CKEditor through FE editor was not possible, because of error

```
Uncaught TypeError: Cannot read property 'document' of null
at Object.LinkBrowser.finalizeFunction (RteLinkBrowser.js:66)
```