### PR TITLE
[BUGFIX] Unset page setup before render the toolbars

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -86,6 +86,24 @@ class FrontendEditingInitializationHook
     }
 
     /**
+     * Hook to unset page setup before render the toolbars to speed up the render
+     * the real frontend page will be called and rendered later
+     * with query parameter 'frontend_editing=true'
+     *
+     * @param array $params
+     * @param TypoScriptFrontendController $parentObject
+     * @return void
+     */
+    public function unsetPageSetup(array $params, TypoScriptFrontendController $parentObject)
+    {
+        if (!$this->isFrontendEditingEnabled($parentObject)) {
+            return;
+        }
+        $parentObject->pSetup = [];
+        $parentObject->config['config']['disableAllHeaderCode'] = true;
+    }
+
+    /**
      * Hook to change page output to add the topbar
      *
      * @param array $params

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -15,6 +15,10 @@ if (TYPO3\CMS\Core\Utility\GeneralUtility::_GET('frontend_editing')) {
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/classes/class.frontendedit.php']['edit'] =
     \TYPO3\CMS\FrontendEditing\EditingPanel\FrontendEditingPanel::class;
 
+// Hook to unset page setup before render the toolbars to speed up the render
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['configArrayPostProc']['frontend_editing'] =
+    \TYPO3\CMS\FrontendEditing\Hook\FrontendEditingInitializationHook::class . '->unsetPageSetup';
+
 // Hook to render toolbars
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output']['frontend_editing'] =
     \TYPO3\CMS\FrontendEditing\Hook\FrontendEditingInitializationHook::class . '->main';


### PR DESCRIPTION
This speeds up the render and the real frontend page will be called and rendered later with query parameter 'frontend_editing=true'