### PR TITLE
[FEATURE] Retain scrollbar position after reloading

### DIFF
--- a/Resources/Public/JavaScript/GUI.js
+++ b/Resources/Public/JavaScript/GUI.js
@@ -268,6 +268,12 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Crud', 'TYPO3/CMS/FrontendEditing/E
 
 		deferred.done(function () {
 			Editor.init($iframe, editorConfigurationUrl, resourcePath);
+
+			if (sessionStorage.scrollTop !== 'undefined') {
+				$iframe.contents().scrollTop(sessionStorage.scrollTop);
+				sessionStorage.removeItem('scrollTop');
+			}
+
 			hideLoadingScreen();
 		});
 
@@ -275,6 +281,8 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Crud', 'TYPO3/CMS/FrontendEditing/E
 	}
 
 	function refreshIframe() {
+		sessionStorage.scrollTop = $iframe.contents().scrollTop();
+
 		loadPageIntoIframe(iframeUrl, editorConfigurationUrl);
 	}
 


### PR DESCRIPTION
We save the scroll position only before refreshing the iframe (save/discard changes) and not when browsing the website directly because, in this last case, the user expect the scroll of the page to be on top. For the same reason we remove "scrollTop" from sessionStorage just after getting it.

FIxes: #186