### PR TITLE
[FEATURE] Handle drag&drop of nested CE

### DIFF
--- a/Classes/Controller/ReceiverController.php
+++ b/Classes/Controller/ReceiverController.php
@@ -80,7 +80,8 @@ class ReceiverController
                             $uid,
                             (int)$request->getParsedBody()['beforeUid'],
                             $page,
-                            $colPos
+                            $colPos,
+                            $request->getParsedBody()['defVals'] ?? []
                         );
                         break;
                     case 'lockedRecord':
@@ -234,6 +235,7 @@ class ReceiverController
         int $beforeUid = 0,
         int $pid = 0,
         int $columnPosition = -2,
+        array $defaultValues = [],
         int $container = 0
     ) {
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
@@ -255,6 +257,9 @@ class ReceiverController
         if ($container) {
             $data[$table][$uid]['colPos'] = $container;
         }
+
+        // add default values to datamap array
+        $data[$table][$uid] = array_merge($data[$table][$uid], $defaultValues);
 
         $dataHandler->start($data, $command);
         $dataHandler->process_cmdmap();

--- a/Classes/Service/ContentEditableWrapperService.php
+++ b/Classes/Service/ContentEditableWrapperService.php
@@ -155,14 +155,15 @@ class ContentEditableWrapperService
         $class = 't3-frontend-editing__dropzone';
 
         $dropZone = sprintf(
-            '<div class="%s" ondrop="%s" ondragover="%s" ondragleave="%s" data-new-url="%s" data-moveafter="%d" data-colpos="%d"></div>',
+            '<div class="%s" ondrop="%s" ondragover="%s" ondragleave="%s" data-new-url="%s" data-moveafter="%d" data-colpos="%d" data-defvals="%s"></div>',
             $class,
             $jsFuncOnDrop,
             $jsFuncOnDragover,
             $jsFuncOnDragLeave,
             $this->renderEditOnClickReturnUrl($this->renderNewUrl($table, (int)$uid, (int)$colPos, $defaultValues)),
             $uid,
-            $colPos
+            $colPos,
+            htmlspecialchars(json_encode($defaultValues))
         );
 
         return $prepend ? ($dropZone . $content) : ($content . $dropZone);

--- a/Resources/Public/JavaScript/Crud.js
+++ b/Resources/Public/JavaScript/Crud.js
@@ -201,13 +201,14 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/FrontendEditing'], function ($, Fro
 		});
 	}
 
-	function moveRecord(uid, table, beforeUid, colPos) {
+	function moveRecord(uid, table, beforeUid, colPos, defVals) {
 		this.trigger(F.REQUEST_START);
 
 		var data = {
 			uid: uid,
 			table: table,
-			beforeUid: beforeUid
+			beforeUid: beforeUid,
+			defVals: defVals
 		};
 
 		if (typeof colPos !== 'undefined') {

--- a/Resources/Public/JavaScript/FrontendEditing.js
+++ b/Resources/Public/JavaScript/FrontendEditing.js
@@ -154,6 +154,25 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 			}
 		},
 
+		parseQuery: function (queryString) {
+			var query = {};
+			var a = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+			for (var i = 0; i < a.length; i++) {
+				var b = a[i].split('=');
+				query[decodeURIComponent(b[0])] = decodeURIComponent(b[1] || '');
+			}
+			return query;
+		},
+
+		serializeObj: function (obj) {
+			var str = [];
+			for (var p in obj)
+				if (obj.hasOwnProperty(p)) {
+					str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
+				}
+			return str.join('&');
+		},
+
 		dragCeStart: function (ev) {
 			var movable = parseInt(ev.currentTarget.dataset.movable, 10);
 
@@ -205,9 +224,10 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 				var ceUid = parseInt(ev.dataTransfer.getData('movableUid'), 10);
 				var moveAfter = parseInt($currentTarget.data('moveafter'), 10);
 				var colPos = parseInt($currentTarget.data('colpos'), 10);
+				var defVals = $currentTarget.data('defvals');
 
 				if (ceUid !== moveAfter) {
-					F.moveContent(ceUid, 'tt_content', moveAfter, colPos);
+					F.moveContent(ceUid, 'tt_content', moveAfter, colPos, defVals);
 				}
 			} else {
 				this.dropNewCe(ev);
@@ -215,10 +235,14 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 		},
 
 		dropNewCe: function (ev) {
-			var params = ev.dataTransfer.getData('params');
-			var newUrl = $(ev.currentTarget).data('new-url');
-			var fullUrl = newUrl + params;
-			F.loadInModal(fullUrl);
+			// Merge drop zone query string with new CE query string without override
+			var newUrlParts = $(ev.currentTarget).data('new-url').split('?');
+			var newUrlQueryStringObj = F.parseQuery(newUrlParts[1]);
+			var paramsObj = F.parseQuery(ev.dataTransfer.getData('params').substr(1));
+			var fullUrlObj = {};
+			$.extend(true, fullUrlObj, paramsObj, newUrlQueryStringObj);
+			var fullUrlQueryString = F.serializeObj(fullUrlObj);
+			F.loadInModal(newUrlParts[0] + '?' + fullUrlQueryString);
 		},
 
 		indicateCeStart: function (ev) {

--- a/Resources/Public/JavaScript/FrontendEditing.js
+++ b/Resources/Public/JavaScript/FrontendEditing.js
@@ -174,6 +174,7 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 		},
 
 		dragCeStart: function (ev) {
+			ev.stopPropagation();
 			var movable = parseInt(ev.currentTarget.dataset.movable, 10);
 
 			ev.dataTransfer.setData('params', ev.currentTarget.dataset.params);
@@ -192,6 +193,7 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 		},
 
 		dragCeEnd: function (ev) {
+			ev.stopPropagation();
 			var movable = parseInt(ev.currentTarget.dataset.movable, 10);
 
 			if (movable === 1) {


### PR DESCRIPTION
Additional info about this commit:

1. gridelements hooks to `wizardItemsHook` to add default parameters `tx_gridelements_container` and `tx_gridelements_columns` based on the columns that called the wizard (aka: the position of the button that the editor clicked to start the wizard)
https://github.com/TYPO3-extensions/gridelements/blob/master/Classes/Hooks/WizardItems.php#L315

2. frontend_editing implements the same TYPO3 hook `wizardItemsHook` to generate its CE wizard (the one in the right column of the UI) but, in this case, the editor didn't press any button before the generation of the wizard. But Gridelements hooks there and adds `tx_gridelements_columns=0` as default parameter for every new CE.

3. To make drag&drop to work for gridelements we must create drop zones using frontend_editing hook `dropzoneModifiers` and calling frontend_editing method `ContentEditableWrapperService::wrapContentWithDropzone` passing to it the specific `tx_gridelements_container` and `tx_gridelements_columns` as $defaultValues.

4. To avoid the behavior of point 2, we must merge the drop zone query string with the new CE query string but without override or else `tx_gridelements_columns` will have value=0 instead of the value specified in the drop zone. This is what happens in javascript function `dropNewCe`.

Resolves: #194