### PR TITLE
[BUGFIX] Merge default values with $data array only if set

### DIFF
--- a/Classes/Controller/ReceiverController.php
+++ b/Classes/Controller/ReceiverController.php
@@ -258,8 +258,8 @@ class ReceiverController
             $data[$table][$uid]['colPos'] = $container;
         }
 
-        // add default values to datamap array
-        $data[$table][$uid] = array_merge($data[$table][$uid], $defaultValues);
+        // Add default values to datamap array
+        $data[$table][$uid] = isset($data[$table][$uid]) ? array_merge($data[$table][$uid], $defaultValues) : $defaultValues;
 
         $dataHandler->start($data, $command);
         $dataHandler->process_cmdmap();


### PR DESCRIPTION
$data[$table][$uid] is NULL when using arrows to move elements.
PHP array_merge between NULL and array results NULL and throws error in DataMapProcessor.
This patch avoids this error making sure that $data[$table][$uid] is always an array.