### PR TITLE
Custom record insertion in page

### DIFF
--- a/Classes/Service/ContentEditableWrapperService.php
+++ b/Classes/Service/ContentEditableWrapperService.php
@@ -171,6 +171,7 @@ class ContentEditableWrapperService
      * @param string $tables
      * @param string $content
      * @param array $defaultValues
+     * @param int $pageUid
      * @param bool $prepend
      *
      * @return string
@@ -180,6 +181,7 @@ class ContentEditableWrapperService
         string $tables,
         string $content,
         array $defaultValues = [],
+        int $pageUid = 0,
         bool $prepend = false
     ): string {
         // Check that data is not empty
@@ -194,13 +196,14 @@ class ContentEditableWrapperService
 
         $dropZone = sprintf(
             '<div class="%s" ondrop="%s" ondragover="%s" ondragleave="%s" ' .
-            'data-tables="%s" data-defvals="%s"></div>',
+            'data-tables="%s" data-defvals="%s" data-pid="%s"></div>',
             $class,
             $jsFuncOnDrop,
             $jsFuncOnDragover,
             $jsFuncOnDragLeave,
             $tables,
-            htmlspecialchars(json_encode($defaultValues))
+            htmlspecialchars(json_encode($defaultValues)),
+            $pageUid
         );
 
         return $prepend ? ($dropZone . $content) : ($content . $dropZone);

--- a/Classes/ViewHelpers/CustomDropZoneViewHelper.php
+++ b/Classes/ViewHelpers/CustomDropZoneViewHelper.php
@@ -79,7 +79,7 @@ class CustomDropZoneViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'pageUid',
             'string',
-            'Overriden page uid for new record droped in zone',
+            'Override storage page uid for new record droped in zone',
             false
         );
         $this->registerArgument(

--- a/Classes/ViewHelpers/CustomDropZoneViewHelper.php
+++ b/Classes/ViewHelpers/CustomDropZoneViewHelper.php
@@ -1,0 +1,125 @@
+<?php
+namespace TYPO3\CMS\FrontendEditing\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\FrontendEditing\Service\AccessService;
+use TYPO3\CMS\FrontendEditing\Service\ContentEditableWrapperService;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+/**
+ * View helper to enable frontend editing for records in fluid
+ *
+ * Example:
+ *
+ * <core:customDropZone tables="{0:'tx_news_domain_model_news',1:'tx_whatever'}">
+ *     <p>some content</p>
+ * </core:customDropZone>
+ *
+ * Output:
+ * <p>some content</p>
+ * <div class="t3-frontend-editing__dropzone"
+ *      ondrop="window.parent.F.dropCr(event)"
+ *      ondragover="window.parent.F.dragCeOver(event)"
+ *      ondragleave="window.parent.F.dragCeLeave(event)"
+ *      data-tables="tx_news_domain_model_news,tx_whatever" data-defvals="{}"></div>
+ */
+class CustomDropZoneViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * Disable the escaping of children
+     *
+     * @var bool
+     */
+    protected $escapeChildren = false;
+
+    /**
+     * Disable that the content itself isn't escaped
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Initialize arguments
+     *
+     * @return void
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument(
+            'tables',
+            'array',
+            'The database tables name allowed to be droped',
+            true
+        );
+        $this->registerArgument(
+            'fields',
+            'array',
+            'Default value for new record droped in zone',
+            false
+        );
+        $this->registerArgument(
+            'prepend',
+            'bool',
+            'Prepend the zone to the content',
+            false
+        );
+    }
+
+    /**
+     * Add a content-editable div around the content
+     *
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string Rendered email link
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $content = $renderChildrenClosure();
+        $access = GeneralUtility::makeInstance(AccessService::class);
+        if (!$access->isEnabled()) {
+            return $content;
+        }
+
+        /** @var ContentEditableWrapperService $wrapperService */
+        $wrapperService = GeneralUtility::makeInstance(ContentEditableWrapperService::class);
+        $defaultValues = [];
+        foreach ($arguments['fields'] as $field => $value) {
+            foreach ($arguments['tables'] as $table) {
+                $defaultValues['defVals[' . $table . '][' . $field . ']'] = $value;
+            }
+        }
+
+        $content = $wrapperService->wrapContentWithCustomDropzone(
+            implode(',', $arguments['tables']),
+            (string)$content,
+            $defaultValues,
+            (bool)$arguments['prepend']
+        );
+
+        return $content;
+    }
+}

--- a/Classes/ViewHelpers/CustomDropZoneViewHelper.php
+++ b/Classes/ViewHelpers/CustomDropZoneViewHelper.php
@@ -77,6 +77,12 @@ class CustomDropZoneViewHelper extends AbstractViewHelper
             false
         );
         $this->registerArgument(
+            'pageUid',
+            'string',
+            'Overriden page uid for new record droped in zone',
+            false
+        );
+        $this->registerArgument(
             'prepend',
             'bool',
             'Prepend the zone to the content',
@@ -117,6 +123,7 @@ class CustomDropZoneViewHelper extends AbstractViewHelper
             implode(',', $arguments['tables']),
             (string)$content,
             $defaultValues,
+            (int)$arguments['pageUid'],
             (bool)$arguments['prepend']
         );
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
-    <file t3:id="1486236619" source-language="en" datatype="plaintext" original="messages" date="2016-10-18T09:11:39Z" product-name="frontend_editing">
+    <file t3:id="1486236619" source-language="en" datatype="plaintext" original="messages" date="2016-10-18T09:11:39Z"
+          product-name="frontend_editing">
         <header/>
         <body>
             <trans-unit id="settings.field.frontend_editing">
@@ -37,7 +38,7 @@
                 <source>Content saved</source>
             </trans-unit>
             <trans-unit id="notifications.save-description">
-                <source>Saved the content with identifier: </source>
+                <source>Saved the content with identifier:</source>
             </trans-unit>
             <trans-unit id="notifications.save-went-wrong">
                 <source>Something went wrong</source>
@@ -91,7 +92,9 @@
             <trans-unit id="right-bar.on-page.title">
                 <source>Elements on page</source>
             </trans-unit>
-
+            <trans-unit id="right-bar.custom-record.title">
+                <source>Custom records</source>
+            </trans-unit>
             <trans-unit id="left-bar.installation-mounts.change">
                 <source>Choose site root</source>
             </trans-unit>

--- a/Resources/Private/Partials/CustomRecordTab.html
+++ b/Resources/Private/Partials/CustomRecordTab.html
@@ -1,0 +1,31 @@
+{namespace core=TYPO3\CMS\Core\ViewHelpers}
+
+<div class="custom-record-tab dark-transparent-bg accordion-container accordion-list" data-wizard-type="ce-custom-records">
+	<div class="accordion ">
+		<div class="element-title">
+			<span class="title-left"><f:translate key="right-bar.custom-record.title" extensionName="FrontendEditing" /></span>
+		</div>
+		<div class="element-action">
+			<span class="icons icon-icons-arrow-down trigger"></span>
+		</div>
+	</div>
+	<div class="accordion-content">
+		<f:for each="{customRecords}" as="customRecord">
+			<div class="element"
+				 draggable="true"
+				 ondragstart="F.dragCrStart(event)"
+				 ondragend="F.dragCrEnd(event)"
+				 data-table="{customRecord.table}"
+				 data-url="{customRecord.url}"
+			>
+				<span class="content-icon-default">
+					<core:iconForRecord table="{customRecord.table}" row="{customRecord}" size="default" />
+				</span>
+				<div class="description">
+					<span class="title-default"><f:translate id="{customRecord.title}" /></span>
+					<span class="title-default title-normal-casing">{customRecord.table}</span>
+				</div>
+			</div>
+		</f:for>
+	</div>
+</div>

--- a/Resources/Private/Partials/RightBar.html
+++ b/Resources/Private/Partials/RightBar.html
@@ -37,5 +37,8 @@
 		<div class="elements">
 			<f:render partial="ContentElementHierarchyTab" arguments="{_all}"></f:render>
 		</div>
+		<div class="elements">
+			<f:render partial="CustomRecordTab" arguments="{_all}"></f:render>
+		</div>
 	</div>
 </div>

--- a/Resources/Public/JavaScript/FrontendEditing.js
+++ b/Resources/Public/JavaScript/FrontendEditing.js
@@ -189,6 +189,7 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 			}
 
 			var $iframe = F.iframe();
+			$iframe.contents().find('.t3-frontend-editing__dropzone[data-tables]').addClass('t3-frontend-editing__dropzone-hidden');
 			$iframe.contents().find('body').addClass('dropzones-enabled');
 		},
 
@@ -204,6 +205,7 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 			}
 
 			var $iframe = F.iframe();
+			$iframe.contents().find('.t3-frontend-editing__dropzone[data-tables]').removeClass('t3-frontend-editing__dropzone-hidden');
 			$iframe.contents().find('body').removeClass('dropzones-enabled');
 		},
 
@@ -268,6 +270,46 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 			var $iframe = F.iframe();
 			$iframe.contents().find('#c' + ev.currentTarget.dataset.uid).parent().removeClass('indicate-element');
 			window.clearTimeout(indicateCeScrollTimeoutId);
+		},
+
+		dropCr: function (ev) {
+			ev.preventDefault();
+			var url = ev.dataTransfer.getData('new-url');
+			if(!ev.dataTransfer.getData('table') && url){
+				return false;
+			}
+			try{
+				var defaultValues = $(ev.currentTarget).data('defvals');
+				var newUrlParts = url.split('?');
+				var newUrlQueryStringObj = F.parseQuery(newUrlParts[1]);
+				var fullUrlObj = {};
+				$.extend(true, fullUrlObj, defaultValues, newUrlQueryStringObj);
+				var fullUrlQueryString = F.serializeObj(fullUrlObj);
+				F.loadInModal(newUrlParts[0] + '?' + fullUrlQueryString);
+			}catch(e){
+				F.loadInModal(url);
+			}
+		},
+
+		dragCrStart: function (ev) {
+			ev.stopPropagation();
+			var table = ev.currentTarget.dataset.table;
+			var $iframe = F.iframe();
+
+			ev.dataTransfer.setData('table', table);
+			ev.dataTransfer.setData('new-url', ev.currentTarget.dataset.url);
+
+			$iframe.contents().find('.t3-frontend-editing__dropzone').not('[data-tables~="' + table + '"]').addClass('t3-frontend-editing__dropzone-hidden');
+			$iframe.contents().find('body').addClass('dropzones-enabled');
+		},
+
+		dragCrEnd: function (ev) {
+			ev.stopPropagation();
+			var table = ev.currentTarget.dataset.table;
+			var $iframe = F.iframe();
+
+			$iframe.contents().find('.t3-frontend-editing__dropzone').not('[data-tables~="' + table + '"]').removeClass('t3-frontend-editing__dropzone-hidden');
+			$iframe.contents().find('body').removeClass('dropzones-enabled');
 		}
 	};
 

--- a/Resources/Public/JavaScript/FrontendEditing.js
+++ b/Resources/Public/JavaScript/FrontendEditing.js
@@ -278,6 +278,11 @@ define(['jquery', 'TYPO3/CMS/FrontendEditing/Storage'], function ($, Storage) {
 			if(!ev.dataTransfer.getData('table') && url){
 				return false;
 			}
+			var pageUid = parseInt($(ev.currentTarget).data('pid'), 10) || 0;
+			if (pageUid > 0) {
+				// TODO: Find a better solution than simply replace in URL
+				url = url.replace(/%5D%5B\d+%5D=new/, '%5D%5B' + pageUid + '%5D=new');
+			}
 			try{
 				var defaultValues = $(ev.currentTarget).data('defvals');
 				var newUrlParts = url.split('?');

--- a/Tests/Unit/Fixtures/ContentEditableFixtures.php
+++ b/Tests/Unit/Fixtures/ContentEditableFixtures.php
@@ -15,6 +15,8 @@ namespace TYPO3\CMS\FrontendEditing\Tests\Unit\Fixtures;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\FrontendEditing\Service\AccessService;
 use TYPO3\CMS\FrontendEditing\Service\ContentEditableWrapperService;
 
 /**
@@ -47,6 +49,14 @@ class ContentEditableFixtures
      * @var string
      */
     protected $content = 'This is my content';
+
+    /**
+     * @var array
+     */
+    protected $customTables = [
+        'tx_news_domain_model_model1',
+        'tx_news_domain_model_model2'
+    ];
 
     /**
      * @var array
@@ -96,6 +106,14 @@ class ContentEditableFixtures
     public function getContent()
     {
         return $this->content;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCustomTables()
+    {
+        return $this->customTables;
     }
 
     /**
@@ -201,5 +219,48 @@ class ContentEditableFixtures
         );
 
         return $expectedOutput;
+    }
+
+    /**
+     * A public getter for getting the correct expected wrapping for custom dropzone
+     *
+     * @param string $content
+     *
+     * @return string
+     */
+    public function getWrapWithCustomDropzoneExpectedContent(string $content = '')
+    {
+        $jsFuncOnDrop = 'window.parent.F.dropCr(event)';
+        $jsFuncOnDragover = 'window.parent.F.dragCeOver(event)';
+        $jsFuncOnDragLeave = 'window.parent.F.dragCeLeave(event)';
+        $class = 't3-frontend-editing__dropzone';
+
+        $tables = implode(',', $this->customTables);
+        $defaultValues = [];
+
+        $expectedOutput = sprintf(
+            '<div class="%s" ondrop="%s" ondragover="%s" ondragleave="%s" ' .
+            'data-tables="%s" data-defvals="%s"></div>',
+            $class,
+            $jsFuncOnDrop,
+            $jsFuncOnDragover,
+            $jsFuncOnDragLeave,
+            $tables,
+            htmlspecialchars(json_encode($defaultValues))
+        );
+
+        return $content . $expectedOutput;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public static function setAccessServiceEnabled(bool $enabled)
+    {
+        $access = GeneralUtility::makeInstance(AccessService::class);
+        $reflection = new \ReflectionClass($access);
+        $reflectionProperty = $reflection->getProperty('isEnabled');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($access, $enabled);
     }
 }

--- a/Tests/Unit/Fixtures/ContentEditableFixtures.php
+++ b/Tests/Unit/Fixtures/ContentEditableFixtures.php
@@ -237,16 +237,18 @@ class ContentEditableFixtures
 
         $tables = implode(',', $this->customTables);
         $defaultValues = [];
+        $pageUid = 0;
 
         $expectedOutput = sprintf(
             '<div class="%s" ondrop="%s" ondragover="%s" ondragleave="%s" ' .
-            'data-tables="%s" data-defvals="%s"></div>',
+            'data-tables="%s" data-defvals="%s" data-pid="%s"></div>',
             $class,
             $jsFuncOnDrop,
             $jsFuncOnDragover,
             $jsFuncOnDragLeave,
             $tables,
-            htmlspecialchars(json_encode($defaultValues))
+            htmlspecialchars(json_encode($defaultValues)),
+            $pageUid
         );
 
         return $content . $expectedOutput;

--- a/Tests/Unit/ViewHelpers/CustomDropZoneViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/CustomDropZoneViewHelperTest.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+namespace TYPO3\CMS\FrontendEditing\Tests\Unit\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Nimut\TestingFramework\TestCase\ViewHelperBaseTestcase;
+use TYPO3\CMS\FrontendEditing\Tests\Unit\Fixtures\ContentEditableFixtures;
+
+use Nimut\TestingFramework\Rendering\RenderingContextFixture;
+use TYPO3\CMS\FrontendEditing\ViewHelpers\CustomDropZoneViewHelper;
+
+/**
+ * Test case for TYPO3\CMS\FrontendEditing\ViewHelpers\CustomDropZoneViewHelper
+ */
+class CustomDropZoneViewHelperTest extends ViewHelperBaseTestcase
+{
+
+    /**
+     * @test
+     */
+    public function testInitializeArgumentsRegistersExpectedArguments()
+    {
+        $instance = $this->getMock(CustomDropZoneViewHelper::class, ['registerArgument']);
+        $instance->expects($this->at(0))->method('registerArgument')->with(
+            'tables',
+            'array',
+            $this->anything(),
+            true,
+            false
+        );
+        $instance->expects($this->at(1))->method('registerArgument')->with(
+            'fields',
+            'array',
+            $this->anything(),
+            false,
+            false
+        );
+        $instance->expects($this->at(2))->method('registerArgument')->with(
+            'prepend',
+            'bool',
+            $this->anything(),
+            false,
+            false
+        );
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $instance->initializeArguments();
+    }
+
+    /**
+     * @dataProvider getRenderTestValuesWithoutFrontendEditionEnabled
+     * @param mixed $value
+     * @param array $arguments
+     * @param string $expected
+     */
+    public function testRenderWithoutFrontendEditingEnabled($value, array $arguments, $expected)
+    {
+        $instance = $this->getMock(CustomDropZoneViewHelper::class, ['renderChildren']);
+        $instance->expects($this->once())->method('renderChildren')->willReturn($value);
+        $instance->setArguments($arguments);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $result = $instance->render();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @dataProvider getRenderTestValuesWithFrontendEditionEnabled
+     * @param mixed $value
+     * @param array $arguments
+     * @param string $expected
+     */
+    public function testRenderWithFrontendEditingEnabled($value, array $arguments, $expected)
+    {
+        ContentEditableFixtures::setAccessServiceEnabled(true);
+        $instance = $this->getMock(CustomDropZoneViewHelper::class, ['renderChildren']);
+        $instance->expects($this->once())->method('renderChildren')->willReturn($value);
+        $instance->setArguments($arguments);
+        $instance->setRenderingContext(new RenderingContextFixture());
+        $result = $instance->render();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function getRenderTestValuesWithoutFrontendEditionEnabled()
+    {
+        $fixtures = new ContentEditableFixtures();
+
+        return [
+            [
+                'My content',
+                [
+                    'tables' => $fixtures->getCustomTables(),
+                    'fields' => [],
+                    'prepend' => false
+                ],
+                'My content',
+            ]
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getRenderTestValuesWithFrontendEditionEnabled()
+    {
+        $fixtures = new ContentEditableFixtures();
+
+        return [
+            [
+                'My content',
+                [
+                    'tables' => $fixtures->getCustomTables(),
+                    'fields' => [],
+                    'prepend' => false
+                ],
+                $fixtures->getWrapWithCustomDropzoneExpectedContent('My content')
+            ]
+        ];
+    }
+}

--- a/Tests/Unit/ViewHelpers/CustomDropZoneViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/CustomDropZoneViewHelperTest.php
@@ -48,6 +48,13 @@ class CustomDropZoneViewHelperTest extends ViewHelperBaseTestcase
             false
         );
         $instance->expects($this->at(2))->method('registerArgument')->with(
+            'pageUid',
+            'string',
+            $this->anything(),
+            false,
+            false
+        );
+        $instance->expects($this->at(3))->method('registerArgument')->with(
             'prepend',
             'bool',
             $this->anything(),
@@ -104,6 +111,7 @@ class CustomDropZoneViewHelperTest extends ViewHelperBaseTestcase
                 [
                     'tables' => $fixtures->getCustomTables(),
                     'fields' => [],
+                    'pageUid' => 0,
                     'prepend' => false
                 ],
                 'My content',
@@ -124,6 +132,7 @@ class CustomDropZoneViewHelperTest extends ViewHelperBaseTestcase
                 [
                     'tables' => $fixtures->getCustomTables(),
                     'fields' => [],
+                    'pageUid' => 0,
                     'prepend' => false
                 ],
                 $fixtures->getWrapWithCustomDropzoneExpectedContent('My content')


### PR DESCRIPTION
With this feature, webmaster is allowed to insert directly record into custom configured zone.
For exemple: a webmaster can insert directly news into the news list.

Configuration is done in 2 part:

1. A custom zone is added via "CustomDropZoneViewHelper" in record listing
2. Allowed record are registred in TypoScript as follow
```
plugin.tx_frontendediting{
    customRecords{
        10{
            table = tx_news_domain_model_news
            pid = 6
        }
    }
}
```
The result will be this:
![20170726205943-printsreen](https://user-images.githubusercontent.com/1862276/28638516-603636d8-7245-11e7-8300-2c7032f9dcd1.png)
