### PR TITLE
[BUGFIX] Remove include of non existing userTsConfig.ts file

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -74,11 +74,6 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['FrontendEditing']['requestPreProcess'
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['FrontendEditing']['requestPreProcess']['frontend_editing-CeHeader'] =
     \TYPO3\CMS\FrontendEditing\RequestPreProcess\CeHeader::class;
 
-// Add UserTsConfig settings
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(
-    '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:frontend_editing/Configuration/UserTsConfig/userTsConfig.ts">'
-);
-
 // Register BE user avatar provider on FE
 if (TYPO3_MODE === 'FE' &&
     \TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_branch) <


### PR DESCRIPTION
The file userTsConfig.ts was deleted with commit [dc861b8](https://github.com/FriendsOfTYPO3/frontend_editing/commit/dc861b89819eea92c38ff14cc6080f77020ef7fb). Include of file was still there and causes errors/warnings on commandline.