### PR TITLE
[BUGFIX] Don't display inline editing if the CE is read-only

### DIFF
--- a/Classes/Service/AccessService.php
+++ b/Classes/Service/AccessService.php
@@ -64,13 +64,18 @@ class AccessService implements SingletonInterface
     }
 
     /**
-     * Has the user edit rights for page?
+     * Has the user edit rights for page? (works with current page by default)
+     *
+     * @param array $page
      *
      * @return bool
      */
-    public function isPageEditAllowed(): bool
+    public function isPageEditAllowed($page = []): bool
     {
-        return $GLOBALS['BE_USER']->doesUserHaveAccess($GLOBALS['TSFE']->page, Permission::PAGE_EDIT);
+        if (!$page) {
+            $page = $GLOBALS['TSFE']->page;
+        }
+        return $GLOBALS['BE_USER']->doesUserHaveAccess($page, Permission::PAGE_EDIT);
     }
 
     /**
@@ -81,5 +86,20 @@ class AccessService implements SingletonInterface
     public function isPageCreateAllowed(): bool
     {
         return $GLOBALS['BE_USER']->doesUserHaveAccess($GLOBALS['TSFE']->page, Permission::PAGE_NEW);
+    }
+
+    /**
+     * Has the user edit rights for the parent page of a given content element?
+     *
+     * @param string $table
+     * @param int $uid
+     *
+     * @return bool
+     */
+    public function isParentPageEditAllowed($table, $uid): bool
+    {
+		$currentCE = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord($table, $uid);
+		$pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class);
+        return $this->isPageEditAllowed($pageRepository->getPage($currentCE['pid']), Permission::PAGE_EDIT);
     }
 }

--- a/Classes/Service/AccessService.php
+++ b/Classes/Service/AccessService.php
@@ -98,8 +98,8 @@ class AccessService implements SingletonInterface
      */
     public function isParentPageEditAllowed($table, $uid): bool
     {
-		$currentCE = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord($table, $uid);
-		$pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class);
+        $currentCE = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord($table, $uid);
+        $pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class);
         return $this->isPageEditAllowed($pageRepository->getPage($currentCE['pid']), Permission::PAGE_EDIT);
     }
 }

--- a/Classes/Service/AccessService.php
+++ b/Classes/Service/AccessService.php
@@ -92,7 +92,7 @@ class AccessService implements SingletonInterface
      * Has the user edit rights for the parent page of a given content element?
      *
      * @param string $table
-     * @param int $uid
+     * @param int    $uid
      *
      * @return bool
      */

--- a/Classes/ViewHelpers/ContentEditableViewHelper.php
+++ b/Classes/ViewHelpers/ContentEditableViewHelper.php
@@ -84,8 +84,8 @@ class ContentEditableViewHelper extends AbstractViewHelper
     /**
      * Add a content-editable div around the content
      *
-     * @param array $arguments
-     * @param \Closure $renderChildrenClosure
+     * @param array                     $arguments
+     * @param \Closure                  $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      *
      * @return string Rendered email link

--- a/Classes/ViewHelpers/ContentEditableViewHelper.php
+++ b/Classes/ViewHelpers/ContentEditableViewHelper.php
@@ -98,7 +98,7 @@ class ContentEditableViewHelper extends AbstractViewHelper
         $content = $renderChildrenClosure();
         $content = ($content != null ? $content : '');
         $access = GeneralUtility::makeInstance(AccessService::class);
-        if (!$access->isEnabled()) {
+        if (!$access->isEnabled() || !$access->isParentPageEditAllowed($arguments['table'], $arguments['uid'])) {
             return $content;
         }
 


### PR DESCRIPTION
This fixes a bug when : 
- Some content elements of a page are fetched from another page, which is not editable by the BE user 
- We are using the `core:contentEditable` viewhelper to enable inline editing with fluid_styled_content.

The error displayed in the system log is `Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1437679657: No content edit permission for user 250 on page 3423 | TYPO3\CMS\Backend\Form\Exception\AccessDeniedContentEditException thrown in file /home/typo3/source/typo3_src-8.7.9/typo3/sysext/backend/Classes/Form/FormDataProvider/DatabaseUserPermissionCheck.php in line 134. Requested URL: https://xxxxxx/typo3/index.php?ajaxID=%2Fajax%2Ffrontend-editing%2Feditor-configuration&ajaxToken=50692c64c3ba0d19aa76ea7e5b2848abf44dcbbc&page=4063&table=tt_content&uid=33583&field=header`
... and it happens each time the page is loaded in frontend editing mode, so it's quickly filling the system log.

It is triggered by `\Controller\EditController\` on line :
`$this->formData = $formDataCompiler->compile($formDataCompilerInput);`

The suggested fix disables inline editing when the user does not have the required rights to edit. There's probably a cleaner way of doing this, but at least it solved my specific issue.