### PR TITLE
[BUGFIX] User's language not set 

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -163,6 +163,7 @@ class FrontendEditingInitializationHook
         // If not language service is set then create one
         if ($GLOBALS['LANG'] === null) {
             $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageService::class);
+            $GLOBALS['LANG']->init($GLOBALS['BE_USER']->uc['lang']);
         }
 
         // Initialize backend routes


### PR DESCRIPTION
Hello

When LANG object is initialized in the frontend editing hook, the language of the user is not initialized.

Regards,
Stéphane