### PR TITLE
[BUGFIX] Right check for editing page content

### DIFF
--- a/Classes/Service/AccessService.php
+++ b/Classes/Service/AccessService.php
@@ -89,23 +89,14 @@ class AccessService implements SingletonInterface
     }
 
     /**
-     * Has the user edit rights for the parent page of a given content element?
+     * Has the user edit rights for the content of the page?
      *
-     * @param string $table
-     * @param int    $uid
+     * @param array $page
      *
      * @return bool
      */
-    public function isParentPageEditAllowed($table, $uid): bool
+    public function isPageContentEditAllowed(array $page): bool
     {
-        try {
-            $currentCE = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord($table, $uid);
-            $pageRepository = GeneralUtility::makeInstance(\TYPO3\CMS\Frontend\Page\PageRepository::class);
-            return $this->isPageEditAllowed($pageRepository->getPage($currentCE['pid']), Permission::PAGE_EDIT);
-        } catch (\Exception $exception) {
-            // Suppress and continue access check
-        }
-
-        return true;
+        return $GLOBALS['BE_USER']->doesUserHaveAccess($page, Permission::CONTENT_EDIT);
     }
 }

--- a/Classes/ViewHelpers/ContentEditableViewHelper.php
+++ b/Classes/ViewHelpers/ContentEditableViewHelper.php
@@ -16,6 +16,7 @@ namespace TYPO3\CMS\FrontendEditing\ViewHelpers;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Page\PageRepository;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
 use TYPO3\CMS\FrontendEditing\Service\AccessService;
 use TYPO3\CMS\FrontendEditing\Service\ContentEditableWrapperService;
@@ -85,8 +86,8 @@ class ContentEditableViewHelper extends AbstractViewHelper
     /**
      * Add a content-editable div around the content
      *
-     * @param array                     $arguments
-     * @param \Closure                  $renderChildrenClosure
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
      * @param RenderingContextInterface $renderingContext
      *
      * @return string Rendered email link
@@ -98,13 +99,16 @@ class ContentEditableViewHelper extends AbstractViewHelper
     ) {
         $content = $renderChildrenClosure();
         $content = ($content != null ? $content : '');
+        $record = BackendUtility::getRecord($arguments['table'], (int)$arguments['uid']);
+
         $access = GeneralUtility::makeInstance(AccessService::class);
-        if (!$access->isEnabled() || !$access->isParentPageEditAllowed($arguments['table'], $arguments['uid'])) {
+        if (!$access->isEnabled()
+            || !$access->isPageContentEditAllowed(GeneralUtility::makeInstance(PageRepository::class)->getPage_noCheck($record['pid']))
+        ) {
             return $content;
         }
 
         $wrapperService = GeneralUtility::makeInstance(ContentEditableWrapperService::class);
-        $record = BackendUtility::getRecord($arguments['table'], (int)$arguments['uid']);
         if (empty($arguments['field'])) {
             $content = $wrapperService->wrapContent(
                 $arguments['table'],


### PR DESCRIPTION
When editing content, it must be checked that the
Permission::CONTENT_EDIT is set. Not the Permission::PAGE_EDIT.

To check storage pages too, the page is fetched with
PageRepository->getPage_noCheck.