### PR TITLE
New content element can only be added to empty page

### DIFF
--- a/Resources/Private/Sass/inline_editing.scss
+++ b/Resources/Private/Sass/inline_editing.scss
@@ -44,6 +44,7 @@
 // dropzone (areas where you can add content)
 
 .t3-frontend-editing__dropzone {
+    display: block;
     height: 0;
     background-color: $color-t3-primary;
     transition: height 0.2s;


### PR DESCRIPTION
Make sure that dropzone always display as block