### PR TITLE
WIP: Update Editor Events for Ajax Content

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -246,6 +246,7 @@ class FrontendEditingInitializationHook
             window.F.setBESessionId(' . GeneralUtility::quoteJSvalue($this->getBeSessionKey()) . ');
             window.F.setFilteringUrl(' . GeneralUtility::quoteJSvalue($filteringUrl) . ');
             window.F.setTranslationLabels(' . json_encode($this->getLocalizedFrontendLabels()) . ');
+            window.FrontendEditingMode = true;
             window.TYPO3.settings = {
                 Textarea: {
                     RTEPopupWindow: {

--- a/Resources/Public/JavaScript/GUI.js
+++ b/Resources/Public/JavaScript/GUI.js
@@ -57,6 +57,7 @@ define([
 	FrontendEditing.prototype.windowOpen = windowOpen;
 	FrontendEditing.prototype.iframe = getIframe;
 	FrontendEditing.prototype.siteRootChange = siteRootChange;
+	FrontendEditing.prototype.initCustomLoadedContent = initCustomLoadedContent;
 
 	var CLASS_HIDDEN = 'hidden';
 
@@ -439,6 +440,10 @@ define([
 		});
 
 		iframeUrl = url;
+	}
+
+	function initCustomLoadedContent(customElement) {
+		Editor.init(customElement, editorConfigurationUrl, resourcePath);
 	}
 
 	function refreshIframe() {


### PR DESCRIPTION
1. Add global variable flag that determinate if page is running in FE editing mode.
Example usage in custom JS
`
if (typeof window.top.FrontendEditingMode !== 'undefined') {
// Do something
}
`
 2. Example of ajax call
```js
function getContent(element) {
	var url = "http://" + window.location.hostname + "?type=5";
	var editingMode = typeof window.top.FrontendEditingMode !== 'undefined';

	if (editingMode) {
		url += "frontend_editing=true&no_cache=1";
	}
	$.ajax({
		url: url,
		dataType: "html",
		success: function (html_content) {
			$(element)
				.css("display", "none")
				.html(html_content)
				.fadeIn();

			if (editingMode) {
				window.top.F.initCustomLoadedContent($(element));
			}
		}
	});
}

getContent('#ajax');
```