### PR TITLE
[FEATURE] Speed improvement when fetching editing configurations

### DIFF
--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -61,7 +61,7 @@ class EditorController
 
         $configurations = [];
         $elements = [];
-        foreach($queryParameters['elements'] as $element) {
+        foreach ($queryParameters['elements'] as $element) {
             $table = $element['table'];
             $uid = (int)$element['uid'];
             $fieldName = $element['field'];

--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -110,7 +110,7 @@ class EditorController
                 $configurations[$configurationKey] = $configuration;
             }
 
-            $elements[$table . '_' . $uid . '_' . $fieldName] = $configurationKey;
+            $elements[$uid . '_' . $table . '_' . $fieldName] = $configurationKey;
         }
 
         $response->getBody()->write(json_encode([

--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Localization\Locales;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
@@ -51,48 +52,72 @@ class EditorController
      */
     public function getConfigurationAction(ServerRequestInterface $request, ResponseInterface $response)
     {
-        $queryParameters = $request->getQueryParams();
-        $table = $queryParameters['table'];
-        $uid = (int)$queryParameters['uid'];
-        $fieldName = $queryParameters['field'];
-
         /** @var TcaDatabaseRecord $formDataGroup */
         $formDataGroup = GeneralUtility::makeInstance(TcaDatabaseRecord::class);
         /** @var FormDataCompiler $formDataCompiler */
         $formDataCompiler = GeneralUtility::makeInstance(FormDataCompiler::class, $formDataGroup);
 
-        $formDataCompilerInput = [
-            'vanillaUid' => (int)$uid,
-            'tableName' => $table,
-            'command' => 'edit',
-            // done intentionally to speed up the compilation of the processedTca
-            'disabledWizards' => true
-        ];
+        $queryParameters = $request->getParsedBody();
 
-        $this->formData = $formDataCompiler->compile($formDataCompilerInput);
-        $formDataFieldName = $this->formData['processedTca']['columns'][$fieldName];
-        $this->rteConfiguration = $formDataFieldName['config']['richtextConfiguration']['editor'];
+        $configurations = [];
+        $elements = [];
+        foreach($queryParameters['elements'] as $element) {
+            $table = $element['table'];
+            $uid = (int)$element['uid'];
+            $fieldName = $element['field'];
 
-        $configuration = $this->prepareConfigurationForEditor();
+            $formDataCompilerInput = [
+                'vanillaUid' => (int)$uid,
+                'tableName' => $table,
+                'command' => 'edit',
+                // done intentionally to speed up the compilation of the processedTca
+                'disabledWizards' => true
+            ];
 
-        $externalPlugins = '';
-        foreach ($this->getExtraPlugins() as $pluginName => $config) {
-            $configuration[$pluginName] = $config['config'];
-            $configuration['extraPlugins'] .= ',' . $pluginName;
+            $this->formData = $formDataCompiler->compile($formDataCompilerInput);
+            $formDataFieldName = $this->formData['processedTca']['columns'][$fieldName];
+            $this->rteConfiguration = $formDataFieldName['config']['richtextConfiguration']['editor'];
 
-            $externalPlugins .= 'CKEDITOR.plugins.addExternal(';
-            $externalPlugins .= GeneralUtility::quoteJSvalue($pluginName) . ',';
-            $externalPlugins .= GeneralUtility::quoteJSvalue($config['resource']) . ',';
-            $externalPlugins .= '\'\');';
+            $editorConfiguration = $this->prepareConfigurationForEditor();
+
+            $externalPlugins = '';
+            foreach ($this->getExtraPlugins() as $pluginName => $config) {
+                $editorConfiguration[$pluginName] = $config['config'];
+                $editorConfiguration['extraPlugins'] .= ',' . $pluginName;
+
+                $externalPlugins .= 'CKEDITOR.plugins.addExternal(';
+                $externalPlugins .= GeneralUtility::quoteJSvalue($pluginName) . ',';
+                $externalPlugins .= GeneralUtility::quoteJSvalue($config['resource']) . ',';
+                $externalPlugins .= '\'\');';
+            }
+
+            $configuration = [
+                'configuration' => $editorConfiguration,
+                'hasCkeditorConfiguration' => $this->rteConfiguration !== null,
+                'externalPlugins' => $externalPlugins,
+            ];
+
+            $configurationKey = '';
+            foreach ($configurations as $existingConfigurationKey => $existingConfiguration) {
+                if (json_encode($existingConfiguration) === json_encode($configuration)) {
+                    $configurationKey = $existingConfigurationKey;
+                    break;
+                }
+            }
+
+            if ($configurationKey === '') {
+                $configurationKey = count($configurations);
+                $configurations[$configurationKey] = $configuration;
+            }
+
+            $elements[$table . '_' . $uid . '_' . $fieldName] = $configurationKey;
         }
 
-        $data = [
-            'configuration' => $configuration,
-            'externalPlugins' => $externalPlugins,
-            'hasCkeditorConfiguration' => $this->rteConfiguration !== null
-        ];
+        $response->getBody()->write(json_encode([
+            'elementToConfiguration' => $elements,
+            'configurations' => $configurations,
+        ]));
 
-        $response->getBody()->write(json_encode($data));
         return $response;
     }
 

--- a/Resources/Public/JavaScript/Editor.js
+++ b/Resources/Public/JavaScript/Editor.js
@@ -257,7 +257,7 @@ define([
 				}
 
 				$(configurableEditableElements).each(function() {
-					var elementIdentifier = $(this).data('table') + '_' + $(this).data('uid') + '_' + $(this).data('field');
+					var elementIdentifier = $(this).data('uid') + '_' + $(this).data('table') + '_' + $(this).data('field');
 
 					var elementData = data.configurations[data.elementToConfiguration[elementIdentifier]];
 

--- a/Resources/Public/JavaScript/Editor.js
+++ b/Resources/Public/JavaScript/Editor.js
@@ -251,15 +251,16 @@ define([
 					'elements': requestData
 				}
 			}).done(function (data) {
-				// Ensure all plugins / buttons are loaded
-				if (typeof data.externalPlugins !== 'undefined') {
-					eval(data.externalPlugins);
-				}
-
 				$(configurableEditableElements).each(function() {
 					var elementIdentifier = $(this).data('uid') + '_' + $(this).data('table') + '_' + $(this).data('field');
 
 					var elementData = data.configurations[data.elementToConfiguration[elementIdentifier]];
+
+					// Ensure all plugins / buttons are loaded
+					if (typeof elementData.externalPlugins !== 'undefined') {
+						eval(elementData.externalPlugins);
+					}
+
 
 					var config = {};
 					if (elementData.hasCkeditorConfiguration) {

--- a/Resources/Public/JavaScript/Editor.js
+++ b/Resources/Public/JavaScript/Editor.js
@@ -203,6 +203,7 @@ define([
 
 		// Add custom configuration to ckeditor
 		var $contenteditable = $iframeContents.find('[contenteditable=\'true\']');
+		var configurableEditableElements = [];
 		$contenteditable.each(function () {
 			var $el = $(this);
 			var $parent = $el.parent();
@@ -228,31 +229,47 @@ define([
 					F.trigger(F.CONTENT_CHANGE);
 				});
 			} else {
-				$.ajax({
-					url: configurationUrl,
-					method: 'GET',
-					dataType: 'json',
-					data: {
-						'table': $(this).data('table'),
-						'uid': $(this).data('uid'),
-						'field': $(this).data('field')
-					}
-				}).done(function (data) {
-					// Ensure all plugins / buttons are loaded
-					if (typeof data.externalPlugins !== 'undefined') {
-						eval(data.externalPlugins);
-					}
+				configurableEditableElements.push(this);
+			}
+		});
 
-					// If there is no CKEditor configuration.
+		var requestData = [];
+		$(configurableEditableElements).each(function() {
+			requestData.push({
+				'table': $(this).data('table'),
+				'uid': $(this).data('uid'),
+				'field': $(this).data('field')
+			});
+		});
+
+		if (requestData.length > 0) {
+			$.ajax({
+				url: configurationUrl,
+				method: 'POST',
+				dataType: 'json',
+				data: {
+					'elements': requestData
+				}
+			}).done(function (data) {
+				// Ensure all plugins / buttons are loaded
+				if (typeof data.externalPlugins !== 'undefined') {
+					eval(data.externalPlugins);
+				}
+
+				$(configurableEditableElements).each(function() {
+					var elementIdentifier = $(this).data('table') + '_' + $(this).data('uid') + '_' + $(this).data('field');
+
+					var elementData = data.configurations[data.elementToConfiguration[elementIdentifier]];
+
 					var config = {};
-					if (data.hasCkeditorConfiguration) {
-						$.extend(true, config, defaultEditorConfig, data.configuration);
+					if (elementData.hasCkeditorConfiguration) {
+						$.extend(true, config, defaultEditorConfig, elementData.configuration);
 					} else {
 						$.extend(true, config, defaultEditorConfig, defaultSimpleEditorConfig);
 					}
 
 					// Initialize CKEditor now, when finished remember any change
-					$el.ckeditor(config).on('instanceReady.ckeditor', function (event, editor) {
+					$(this).ckeditor(config).on('instanceReady.ckeditor', function (event, editor) {
 						// This moves the dom instances of ckeditor into the top bar
 						$('.' + editor.id).detach().appendTo($topBar);
 
@@ -264,7 +281,7 @@ define([
 									'table': dataSet.table,
 									'uid': dataSet.uid,
 									'field': dataSet.field,
-									'hasCkeditorConfiguration': data.hasCkeditorConfiguration,
+									'hasCkeditorConfiguration': elementData.hasCkeditorConfiguration,
 									'editorInstance': editor.name
 								});
 								F.trigger(F.CONTENT_CHANGE);
@@ -272,8 +289,8 @@ define([
 						});
 					});
 				});
-			}
-		});
+			});
+		}
 	}
 
 	return {


### PR DESCRIPTION
Fixes #230. Editor configurations for content element fields were fetched in separate requests, one by one. This had a great impact on speed. The configurations are now fetched all together in a single request.