### PR TITLE
[TASK] add 'stdWrap' settings for 'lib.contentElement'

### DIFF
--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -6,6 +6,8 @@ lib.fluidContent {
     }
 }
 
+lib.contentElement.stdWrap < lib.fluidContent.stdWrap
+
 tt_content.bullets.stdWrap < lib.fluidContent.stdWrap
 tt_content.div.stdWrap < lib.fluidContent.stdWrap
 tt_content.header.stdWrap < lib.fluidContent.stdWrap


### PR DESCRIPTION
1. Fluid Styled Content adds the logic it needs through 'lib.contentElement'
2. Keep 'lib.fluidContent' for backwards compatibility