### PR TITLE
[BUGFIX] Url parameter 'frontend_editing' is removed when rendering page

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -240,10 +240,12 @@ class FrontendEditingInitializationHook
         // so it has to be loaded before
         $availableContentElementTypes = $this->getContentItems();
 
+        $baseUrl = ($this->getPluginConfiguration()['baseUrl']) ? $this->getPluginConfiguration()['baseUrl'] : '/';
+
         // PageRenderer needs to be completely reinitialized
         // Thus, this hack is necessary for now
         $this->pageRenderer = new PageRenderer();
-        $this->pageRenderer->setBaseUrl('/');
+        $this->pageRenderer->setBaseUrl($baseUrl);
         $this->pageRenderer->setCharset('utf-8');
         $this->pageRenderer->addMetaTag('<meta name="viewport" content="width=device-width, initial-scale=1">');
         $this->pageRenderer->addMetaTag('<meta http-equiv="X-UA-Compatible" content="IE=edge">');

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -28,3 +28,10 @@ The following steps are required to active the frontend editing for a TYPO3 inst
 
   .. figure:: ../Images/UserActivationOfFeedit.png
      :alt: User activation of frontend editing
+
+- Optional part is to be able to set the baseUrl for the frontend editing if server path is not a top
+  directory. It is done by adding the following part to Setup typoscript:
+
+  .. code-block:: typoscript
+
+     plugin.tx_frontendediting.baseUrl = /

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -30,7 +30,7 @@ The following steps are required to active the frontend editing for a TYPO3 inst
      :alt: User activation of frontend editing
 
 - Optional part is to be able to set the baseUrl for the frontend editing if server path is not a top
-  directory. It is done by adding the following part to Setup typoscript:
+  directory. It is done by adding the following part to setup typoscript:
 
   .. code-block:: typoscript
 


### PR DESCRIPTION
Clicking links that erroneously contained the 'frontend_editing=true'
would result in loading the page as it would look inside the editing
iframe, i.e. without the frontend editing wrapper and UI.

This addition checks all 'a' tags in the content output and removes
the argument from links by parsing the HTML and modifying the DOM.

Fixes #372