### PR TITLE
[BUGFIX] Editing page title of Siteroot fails

### DIFF
--- a/Classes/Controller/ReceiverController.php
+++ b/Classes/Controller/ReceiverController.php
@@ -148,10 +148,14 @@ class ReceiverController
             ]
         ];
 
-        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->start($data, []);
-        $dataHandler->process_datamap();
-
+        try {
+            $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+            $dataHandler->start($data, []);
+            $dataHandler->process_datamap();
+        } catch (\Exception $exception) {
+            // If editing a Site root the DataHandler is loading additional configuration which
+            // may be faulty. So suppress the Exception and continue because the update action is valid
+        }
         $translateKey = sprintf(
             'notifications.update.%s.',
             $table === 'pages' ? 'pages' : 'content'


### PR DESCRIPTION
If editing a Site root the DataHandler is loading additional configuration which
may be faulty. So suppress the Exception and continue because the update action is valid