### PR TITLE
[BUGFIX] Elements on disabled pages are visible and editable

### DIFF
--- a/Classes/Middleware/FrontendEditingAspect.php
+++ b/Classes/Middleware/FrontendEditingAspect.php
@@ -45,7 +45,7 @@ class FrontendEditingAspect implements MiddlewareInterface
             $context = GeneralUtility::makeInstance(Context::class);
             $context->setAspect(
                 'visibility',
-                GeneralUtility::makeInstance(VisibilityAspect::class, $showHiddenItems, $showHiddenItems)
+                GeneralUtility::makeInstance(VisibilityAspect::class, true, $showHiddenItems)
             );
         }
         return $handler->handle($request);


### PR DESCRIPTION
Fixes #412, where content elements were not editable or visible if the page was disabled.