### PR TITLE
Issue #454 loading won't hide

### DIFF
--- a/Resources/Public/JavaScript/GUI.js
+++ b/Resources/Public/JavaScript/GUI.js
@@ -518,12 +518,11 @@ define([
 	function hideLoadingScreen() {
 		loadingScreenLevel--;
 
-		if (loadingScreenLevel === 0) {
+		if (loadingScreenLevel <= 0) {
+			loadingScreenLevel = 0;
 			$loadingScreen.fadeOut('slow', function () {
 				$loadingScreen.addClass(CLASS_HIDDEN);
 			});
-		} else if (loadingScreenLevel < 0) {
-			loadingScreenLevel = 0;
 		}
 	}
 


### PR DESCRIPTION
The loading overlay doesn't disappear.

Somehow loadingScreenLevel is zero, but should be one.