### PR TITLE
[BUGFIX] Fixed incorrect TypoScript conditions

### DIFF
--- a/Configuration/TypoScript/Compatibility8/setup.ts
+++ b/Configuration/TypoScript/Compatibility8/setup.ts
@@ -1,4 +1,4 @@
-[globalVar = TSFE : beUserLogin > 0][globalVar = GP:frontend_editing = true]
+[globalVar = TSFE : beUserLogin > 0] && [globalVar = GP:frontend_editing = true]
 
 lib.fluidContent {
     stdWrap {

--- a/Configuration/TypoScript/setup.ts
+++ b/Configuration/TypoScript/setup.ts
@@ -1,4 +1,4 @@
-[backend.user.isLoggedIn][request.getQueryParams()['frontend_editing'] == true]
+[backend.user.isLoggedIn && request.getQueryParams()['frontend_editing'] == true]
 
 lib.fluidContent {
     stdWrap {


### PR DESCRIPTION
Missing "&&" caused in an Expression could not be parsed error.