### PR TITLE
Fix TypeError caused by ContentEditableViewHelper

### DIFF
--- a/Classes/ViewHelpers/ContentEditableViewHelper.php
+++ b/Classes/ViewHelpers/ContentEditableViewHelper.php
@@ -153,7 +153,7 @@ class ContentEditableViewHelper extends AbstractTagBasedViewHelper
             $this->arguments['table'],
             $this->arguments['field'],
             (int)$this->arguments['uid'],
-            $content,
+            (string)$content,
             $this->arguments['tag'],
             $filteredArguments
         );


### PR DESCRIPTION
When the ContentEditableViewHelper is used like this:
```html
<core:contentEditable table="tt_content" field="header" uid="{uid}">{header}</core:contentEditable>
```
and the `header` is empty (new content element), it results in a TypeError
> Argument 4 passed to TYPO3\CMS\FrontendEditing\Service\ContentEditableWrapperService::wrapContentToBeEditable() must > be of the type string, null given, called in /var/www/dg/mw/public/typo3conf/ext/frontend_editing/Classes/ViewHelpers/ContentEditableViewHelper.php on line 153

If the `header` is empty, than is `$content` equal `null`. Casting it to string, resolves this issue.