### PR TITLE
Fix CKEditor base path

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -380,7 +380,7 @@ class FrontendEditingInitializationHook
         if ($GLOBALS['TYPO3_CONF_VARS']['FE']['versionNumberInFilename'] === 'embed') {
             $this->pageRenderer->addJsInlineCode(
                 'ckeditor-basepath-config',
-                'window.CKEDITOR_BASEPATH = ' . GeneralUtility::quoteJSvalue(PathUtility::getRelativePathTo(
+                'window.CKEDITOR_BASEPATH = ' . GeneralUtility::quoteJSvalue(PathUtility::getAbsoluteWebPath(
                     GeneralUtility::getFileAbsFileName(
                         'EXT:rte_ckeditor/Resources/Public/JavaScript/Contrib/'
                     )


### PR DESCRIPTION
In the current version the CKEditor base path is resolved like this:
`window.CKEDITOR_BASEPATH = 'typo3\/sysext\/rte_ckeditor\/Resources\/Public\/JavaScript\/Contrib\/';`

Which results in wrong JS resource paths:
![image](https://user-images.githubusercontent.com/3798226/115671897-47f44e80-a34b-11eb-947b-d876112d438b.png)

And a JS error:
![image](https://user-images.githubusercontent.com/3798226/115672011-64908680-a34b-11eb-809c-b794d0eafe78.png)

Using `PathUtility::getAbsoluteWebPath` instead of `PathUtility::getRelativePathTo` solve this issue.

This relates to #426 