### PR TITLE
[BUGFIX] Prevent error when editing disallowed CE

### DIFF
--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -18,6 +18,7 @@ namespace TYPO3\CMS\FrontendEditing\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Form\Exception\AccessDeniedEditInternalsException;
 use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -85,7 +86,12 @@ class EditorController
                     'disabledWizards' => true
                 ];
 
-                $this->formData = $formDataCompiler->compile($formDataCompilerInput);
+                try {
+                    $this->formData = $formDataCompiler->compile($formDataCompilerInput);
+                } catch (AccessDeniedEditInternalsException $exception) {
+                    continue;
+                }
+
                 $formDataFieldName = $this->formData['processedTca']['columns'][$fieldName];
                 $this->rteConfiguration = $formDataFieldName['config']['richtextConfiguration']['editor'];
                 $hasCkeditorConfiguration = $this->rteConfiguration !== null;

--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -19,6 +19,7 @@ namespace TYPO3\CMS\FrontendEditing\Controller;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Form\Exception\AccessDeniedEditInternalsException;
+use TYPO3\CMS\Backend\Form\Exception\AccessDeniedException;
 use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -26,6 +27,7 @@ use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
+use TYPO3\CMS\Form\Exception;
 use TYPO3\CMS\FrontendEditing\Utility\ConfigurationUtility;
 
 /**
@@ -88,7 +90,7 @@ class EditorController
 
                 try {
                     $this->formData = $formDataCompiler->compile($formDataCompilerInput);
-                } catch (AccessDeniedEditInternalsException $exception) {
+                } catch (/* Form exception */ Exception $exception) {
                     continue;
                 }
 

--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -18,8 +18,6 @@ namespace TYPO3\CMS\FrontendEditing\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use TYPO3\CMS\Backend\Form\Exception\AccessDeniedEditInternalsException;
-use TYPO3\CMS\Backend\Form\Exception\AccessDeniedException;
 use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -27,7 +25,7 @@ use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
-use TYPO3\CMS\Form\Exception;
+use TYPO3\CMS\Backend\Form\Exception;
 use TYPO3\CMS\FrontendEditing\Utility\ConfigurationUtility;
 
 /**

--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -18,6 +18,7 @@ namespace TYPO3\CMS\FrontendEditing\Controller;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Form\Exception;
 use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -25,7 +26,6 @@ use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Localization\Locales;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
-use TYPO3\CMS\Backend\Form\Exception;
 use TYPO3\CMS\FrontendEditing\Utility\ConfigurationUtility;
 
 /**

--- a/Resources/Public/JavaScript/Editor.js
+++ b/Resources/Public/JavaScript/Editor.js
@@ -277,6 +277,12 @@ define([
 
           var elementData = data.configurations[data.elementToConfiguration[elementIdentifier]];
 
+          console.log(typeof elementData);
+
+          if (typeof elementData === 'undefined') {
+            return;
+          }
+
           // Ensure all plugins / buttons are loaded
           if (typeof elementData.externalPlugins !== 'undefined') {
             eval(elementData.externalPlugins);

--- a/Resources/Public/JavaScript/Editor.js
+++ b/Resources/Public/JavaScript/Editor.js
@@ -277,8 +277,6 @@ define([
 
           var elementData = data.configurations[data.elementToConfiguration[elementIdentifier]];
 
-          console.log(typeof elementData);
-
           if (typeof elementData === 'undefined') {
             return;
           }

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,19 @@
 	"name": "friendsoftypo3/frontend-editing",
 	"type": "typo3-cms-extension",
 	"description": "Enable editors to work with the content in the most intuitive way possible",
-	"license": ["GPL-2.0-or-later"],
-	"keywords": ["TYPO3 CMS", "Frontend Editing"],
+	"license": [
+		"GPL-2.0-or-later"
+	],
+	"keywords": [
+		"TYPO3 CMS",
+		"Frontend Editing"
+	],
 	"require": {
 		"php": "^7.2",
 		"typo3/cms-core": "^9.5 || ^10.4",
 		"typo3/cms-rte-ckeditor": "^9.5 || ^10.4",
-		"typo3/cms-viewpage": "^9.5 || ^10.4"
+		"typo3/cms-viewpage": "^9.5 || ^10.4",
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"typo3/minimal": "^9.5 || ^10.4",


### PR DESCRIPTION
When a non-admin user was editing a page with a content element the user was not allowed to edit, a 500 error would be shown. It was caused by an AccessDeniedEditInternalsException (1437687404) within DatabaseUserPermissionCheck.

Fixes #552