### PR TITLE
[TASK] Add query parameter ''frontend_editing=true'' to all links when editing

### DIFF
--- a/Classes/UserFunc/HtmlParserUserFunc.php
+++ b/Classes/UserFunc/HtmlParserUserFunc.php
@@ -63,7 +63,7 @@ class HtmlParserUserFunc
 
         $queryArguments = [];
 
-        if ($parsedUrl['query'] !== null) {
+        if (isset($parsedUrl['query']) && $parsedUrl['query'] !== null) {
             $queryArguments = GeneralUtility::explodeUrl2Array($parsedUrl['query']);
         }
 

--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -1,0 +1,3 @@
+plugin.tx_frontendediting {
+  addFrontendEditingQueryParameter = TYPO3\CMS\FrontendEditing\UserFunc\HtmlParserUserFunc->addFrontendEditingInUrl
+}

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -72,12 +72,12 @@
 
           tags {
             a.fixAttrib {
-              href.userFunc = TYPO3\CMS\FrontendEditing\UserFunc\HtmlParserUserFunc->addFrontendEditingInUrl
+              href.userFunc = {$plugin.tx_frontendediting.addFrontendEditingQueryParameter}
               target.list = _self
             }
 
             form.fixAttrib {
-              action.userFunc = TYPO3\CMS\FrontendEditing\UserFunc\HtmlParserUserFunc->addFrontendEditingInUrl
+              action.userFunc = {$plugin.tx_frontendediting.addFrontendEditingQueryParameter}
               target.list = _self
             }
           }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -72,7 +72,7 @@
 
           tags {
             a.fixAttrib {
-              href.userFunc = TYPO3\CMS\FrontendEditing\UserFunc\HtmlParserUserFunc->removeFrontendEditingInUrl
+              href.userFunc = TYPO3\CMS\FrontendEditing\UserFunc\HtmlParserUserFunc->addFrontendEditingInUrl
               target.list = _self
             }
 


### PR DESCRIPTION
Add query parameter ''frontend_editing=true'' to all links when editing. This is to prevent so that when a user are navigating the page with a tags, that the top bar disappears. 