### PR TITLE
[Bugfix] Check should replace full schema http(s)

### DIFF
--- a/Classes/Controller/FrontendEditingModuleController.php
+++ b/Classes/Controller/FrontendEditingModuleController.php
@@ -339,7 +339,7 @@ class FrontendEditingModuleController
             );
 
             // Check for what protocol to use
-            $targetUrl = str_replace('http', $this->getProtocol(), $targetUrl);
+            $targetUrl = str_replace('/https|http/', $this->getProtocol(), $targetUrl);
         } catch (UnableToLinkToPageException $e) {
             $flashMessage = GeneralUtility::makeInstance(
                 FlashMessage::class,


### PR DESCRIPTION
With the latest bugfix for protocol handling in the FrontendEditingModuleController, iframes in HTTPS powered websites are no longer loaded due to an incorrect url (httpss://abc.com/myPage?frontend_editing=true). The replacement should therefore be made here for both cases (http/https).