### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Stable Version](https://poser.pugx.org/friendsoftypo3/frontend-editing/v/stable.svg)](https://extensions.typo3.org/extension/frontend_editing/)
-[![TYPO3](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
+[![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg?style=flat-square)](https://get.typo3.org/version/11)
 [![Total Downloads](https://poser.pugx.org/friendsoftypo3/frontend-editing/d/total.svg)](https://packagist.org/packages/friendsoftypo3/frontend-editing)
 [![Monthly Downloads](https://poser.pugx.org/friendsoftypo3/frontend-editing/d/monthly)](https://packagist.org/packages/friendsoftypo3/frontend-editing)
 [![Build Status](https://travis-ci.org/FriendsOfTYPO3/frontend_editing.svg?branch=master)](https://travis-ci.org/FriendsOfTYPO3/frontend_editing)

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
 	"name": "friendsoftypo3/frontend-editing",
 	"type": "typo3-cms-extension",
 	"description": "Enable editors to work with the content in the most intuitive way possible",
+	"homepage": "https://extensions.typo3.org/extension/frontend_editing/",
+	"support": {
+		"issues": "https://github.com/FriendsOfTYPO3/frontend_editing/issues",
+		"source": "https://github.com/FriendsOfTYPO3/frontend_editing",
+		"docs": "https://docs.typo3.org/p/friendsoftypo3/frontend-editing/main/en-us/"
+	},
 	"license": [
 		"GPL-2.0-or-later"
 	],


### PR DESCRIPTION
Added new commit regarding additional sources (TER, repository and docs.typo3.org) in composer.json.

Relates: TYPO3-Documentation/T3DocTeam#185