### PR TITLE
[BUGFIX] Replace usage of old GET param frontend_editing_enabled

### DIFF
--- a/Classes/Controller/FrontendEditingModuleController.php
+++ b/Classes/Controller/FrontendEditingModuleController.php
@@ -376,11 +376,11 @@ class FrontendEditingModuleController
         $otherDomain = false;
         // Check if the domain I am logged into are the same as the one I try edit for
         if (strpos($targetUrl, $request->getUri()->getHost()) !== false) {
-            // Apply the GET parameter "frontend_editing_enabled"
+            // Apply the GET parameter "frontend_editing"
             if (parse_url($targetUrl, PHP_URL_QUERY)) {
-                $targetUrl = $targetUrl . '&frontend_editing_enabled=true';
+                $targetUrl = $targetUrl . '&frontend_editing=true';
             } else {
-                $targetUrl = $targetUrl . '?frontend_editing_enabled=true';
+                $targetUrl = $targetUrl . '?frontend_editing=true';
             }
         } else {
             $targetUrl = parse_url($targetUrl)['host'];


### PR DESCRIPTION
v3.0.23 just displays a blank page for me and I think you mismatched the GET param in commit eac17c475293074bbc149d5a78cff5f844c0911f with the one from v2. Fixing this works for me. Please check and accept, if my assumptions are correct.