### PR TITLE
[BUGFIX] Use traverse() in TypoScript conditions

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,6 +1,5 @@
-[backend.user.isLoggedIn && (request.getQueryParams()['frontend_editing'] == true || request.getQueryParams()['route'] matches '#^/ajax/frontend-editing/#')]
-
-  lib.fluidContent {
+[backend.user.isLoggedIn && (traverse(request.getQueryParams(), 'frontend_editing') == true || traverse(request.getQueryParams(), 'route') matches '#^/ajax/frontend-editing/#')]
+lib.fluidContent {
     stdWrap {
       editIcons = tt_content:header
     }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,5 +1,5 @@
 [backend.user.isLoggedIn && (traverse(request.getQueryParams(), 'frontend_editing') == true || traverse(request.getQueryParams(), 'route') matches '#^/ajax/frontend-editing/#')]
-lib.fluidContent {
+  lib.fluidContent {
     stdWrap {
       editIcons = tt_content:header
     }


### PR DESCRIPTION
Removes potential for error messages in PHP 8