### PR TITLE
[BUGFIX] Shorten the value for FRONTEND_EDITING_ALREADY_LOADED

### DIFF
--- a/Classes/Hook/FrontendEditingInitializationHook.php
+++ b/Classes/Hook/FrontendEditingInitializationHook.php
@@ -53,7 +53,7 @@ use TYPO3\CMS\FrontendEditing\Utility\FrontendEditingUtility;
  */
 class FrontendEditingInitializationHook
 {
-    const FRONTEND_EDITING_ALREADY_LOADED = 'frontend_editing_already_loaded';
+    const FRONTEND_EDITING_ALREADY_LOADED = 'fe_editing_already_loaded';
 
     /**
      * @var AccessService


### PR DESCRIPTION
The value of the constant needed to be less that 30 characters. This is due to the fact that VariableProcessor have a maximum value of 30, otherwise it gets resolveHash gets corrupted.

Fixes: #627