### PR TITLE
[BUGFIX] Exclude dev-only files from package distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+/.ddev export-ignore
+/.github export-ignore
+/Build export-ignore
+/Tests export-ignore
+/.crowdin.yaml export-ignore
+/.editorconfig export-ignore
+/.eslintrc.json export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php-cs-fixer.php export-ignore
+/.stylelintrc.json export-ignore
+/jest.config.js export-ignore
+/package.json export-ignore
+/postcss.config.js export-ignore
+/webpack.contrib.config.js export-ignore
+


### PR DESCRIPTION
Several development-only files must not be distributed when installing this extension using Composer with `prefer-dist` being active. We can skip those files by providing a `.gitattributes` file that contains [`export-ignore`](https://git-scm.com/docs/git-archive#Documentation/git-archive.txt-export-ignore) rules for all development-only files and directories.