### PR TITLE
[FIX] fix errors on install tool check for broken extensions

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -9,3 +9,9 @@ ExtensionManagementUtility::addStaticFile(
     'Configuration/TypoScript',
     'Frontend Editing'
 );
+
+ExtensionManagementUtility::addStaticFile(
+    'frontend_editing',
+    'Configuration/TypoScript/FluidStyledContent9',
+    'Editable Fluid Styled Content v9'
+);

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -15,9 +15,3 @@ defined('TYPO3') or die();
         'labels' => 'LLL:EXT:frontend_editing/Resources/Private/Language/locallang_mod.xlf',
     ]
 );
-
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-    'frontend_editing',
-    'Configuration/TypoScript/FluidStyledContent9',
-    'Editable Fluid Styled Content v9'
-);


### PR DESCRIPTION
When I run "Check for Broken Extensions" in the install tool or use typo3cms upgrade:prepare I get errors that EXT:frontend_editing is broken: 

> Loading ext_tables.php of extension "frontend_editing" failed

Moving the ExtensionManagementUtility::addStaticFile() call to Configuration/TCAOverrides/sys_template.php fixes this issue. 