### PR TITLE
Fix value of $hasCkeditorConfiguration

### DIFF
--- a/Classes/Controller/EditorController.php
+++ b/Classes/Controller/EditorController.php
@@ -95,7 +95,7 @@ class EditorController
                 $formDataFieldName = $this->formData['processedTca']['columns'][$fieldName];
                 $this->rteConfiguration = (isset($formDataFieldName['config']['richtextConfiguration']))
                     ? $formDataFieldName['config']['richtextConfiguration']['editor'] : [];
-                $hasCkeditorConfiguration = $this->rteConfiguration !== null;
+                $hasCkeditorConfiguration = !empty($this->rteConfiguration);
 
                 $editorConfiguration = $this->prepareConfigurationForEditor();
 


### PR DESCRIPTION
$hasCkeditorConfiguration is always true because $this->rteConfiguration is set to an empty array (not null)