### PR TITLE
[BUGFIX] Exclude fe_editing_already_loaded from cHash calculations

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,6 +7,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['core'][] = 'TYPO3\\CM
 
 // Exclude the frontend editing from the cHash calculations
 $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'frontend_editing';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'fe_editing_already_loaded';
 
 // Copy configuration array so we can have our own.
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['frontendTcaDatabaseRecord'] =


### PR DESCRIPTION
or else every page will return 404 if `$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['enforceValidation'] = true`