### PR TITLE
[BUGFIX] Strengthen request URI check

### DIFF
--- a/Classes/Controller/Event/Handler/BootCompletedEventHandler.php
+++ b/Classes/Controller/Event/Handler/BootCompletedEventHandler.php
@@ -15,6 +15,7 @@ final class BootCompletedEventHandler
 {
     public function __invoke(BootCompletedEvent $event): void
     {
+        // Load JS ParentWindow when user opens the element browser (file selector)
         $requestUri = GeneralUtility::getIndpEnv('REQUEST_URI');
         if ($requestUri !== '') {
             $phpUrlPath = parse_url($requestUri, PHP_URL_PATH);

--- a/Classes/Controller/Event/Handler/BootCompletedEventHandler.php
+++ b/Classes/Controller/Event/Handler/BootCompletedEventHandler.php
@@ -15,12 +15,15 @@ final class BootCompletedEventHandler
 {
     public function __invoke(BootCompletedEvent $event): void
     {
-        if (isset($_SERVER['REQUEST_URI'])) {
-            $path = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
-
-            if (str_ends_with($path, '/browse')) {
-                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
-                $pageRenderer->loadRequireJsModule('TYPO3/CMS/FrontendEditing/ParentWindow');
+        $requestUri = GeneralUtility::getIndpEnv('REQUEST_URI');
+        if ($requestUri !== '') {
+            $phpUrlPath = parse_url($requestUri, PHP_URL_PATH);
+            if ($phpUrlPath) {
+                $path = urldecode($phpUrlPath);
+                if (str_ends_with($path, '/browse')) {
+                    $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+                    $pageRenderer->loadRequireJsModule('TYPO3/CMS/FrontendEditing/ParentWindow');
+                }
             }
         }
     }

--- a/Classes/Controller/Event/Handler/BootCompletedEventHandler.php
+++ b/Classes/Controller/Event/Handler/BootCompletedEventHandler.php
@@ -6,6 +6,7 @@ namespace TYPO3\CMS\FrontendEditing\Controller\Event\Handler;
 
 use TYPO3\CMS\Core\Core\Event\BootCompletedEvent;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Event Handler Boot loading complete.
@@ -15,10 +16,10 @@ final class BootCompletedEventHandler
     public function __invoke(BootCompletedEvent $event): void
     {
         if (isset($_SERVER['REQUEST_URI'])) {
-            $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(PageRenderer::class);
             $path = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
 
             if (str_ends_with($path, '/browse')) {
+                $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
                 $pageRenderer->loadRequireJsModule('TYPO3/CMS/FrontendEditing/ParentWindow');
             }
         }


### PR DESCRIPTION
Crawlers and bots sometimes make request with malformed URI. E.g.:
- https://example.com//example.json" (notice the double slash before example.json)
- https://example.com/:443/favicon.ico

This is to avoid exception in these cases.
