### PR TITLE
[BUGFIX] Default to maximized web_view state if BE user never changed it

### DIFF
--- a/Classes/Controller/FrontendEditingModuleController.php
+++ b/Classes/Controller/FrontendEditingModuleController.php
@@ -203,15 +203,27 @@ class FrontendEditingModuleController
     {
         // Add preset menu to module docheader
         $presetSplitButtonElement = $buttonBar->makeSplitButton();
-        // Current state
-        $current = (isset($this->getBackendUser()->uc['moduleData']['web_view']))
-            ? $this->getBackendUser()->uc['moduleData']['web_view']['States']['current'] : [];
-        $current['label'] = ($current['label'] ?? $this->getLanguageService()->sL('LLL:EXT:viewpage/Resources/Private/Language/locallang.xlf:custom'));
+
         $maximizeButtonLabel = $this->getLanguageService()->getLL('maximized');
+
+        // Current web_view state of the BE user
+        $current = $this->getBackendUser()->uc['moduleData']['web_view']['States']['current'] ?? null;
+
+        // If BE user never changed the web_view state then default to maximized
+        if (!isset($current)) {
+            $current['key'] = 'maximized';
+            $current['label'] = $maximizeButtonLabel;
+            $current['width'] = '';
+            $current['height'] = '';
+        }
+
+        // If the current web_view state is not maximized then set the current width & height used later in width & height inputs
         if ($current['label'] !== $maximizeButtonLabel) {
             $current['width'] = (isset($current['width']) && (int)$current['width'] >= 300 ? (int)$current['width'] : 320);
             $current['height'] = (isset($current['height']) && (int)$current['height'] >= 300 ? (int)$current['height'] : 480);
         }
+
+        // Add the current button to the preset select
         $currentButton = $buttonBar->makeLinkButton()
             ->setHref('#')
             ->setClasses('t3js-preset-current t3js-change-preset')
@@ -225,7 +237,8 @@ class FrontendEditingModuleController
                 'height' => ''
             ]);
         $presetSplitButtonElement->addItem($currentButton, true);
-        // Maximize button
+
+        // Add the maximize button to the preset select
         $maximizeButton = $buttonBar->makeLinkButton()
             ->setHref('#')
             ->setClasses('t3js-preset-maximized t3js-change-preset')
@@ -239,9 +252,9 @@ class FrontendEditingModuleController
                 'height' => ''
             ]);
         $presetSplitButtonElement->addItem($maximizeButton);
-        // Custom button
-        $custom = (isset($this->getBackendUser()->uc['moduleData']['web_view']['States']['custom']))
-            ? $this->getBackendUser()->uc['moduleData']['web_view']['States']['custom'] : [];
+
+        // Add the custom button to the preset select
+        $custom = $this->getBackendUser()->uc['moduleData']['web_view']['States']['custom'] ?? [];
         $custom['width'] = (isset($custom['width']) && (int)$custom['width'] >= 300 ? (int)$custom['width'] : 320);
         $custom['height'] = (isset($custom['height']) && (int)$custom['height'] >= 300 ? (int)$custom['height'] : 480);
         $customButtonLabel = $this->getLanguageService()->getLL('custom');
@@ -258,7 +271,8 @@ class FrontendEditingModuleController
                 'height' => $custom['height']
             ]);
         $presetSplitButtonElement->addItem($customButton);
-        // Presets buttons
+
+        // Add the presets buttons to the preset select
         $presetGroups = $this->getPreviewPresets($pageId);
         foreach ($presetGroups as $presetGroup => $presets) {
             $separatorButton = $buttonBar->makeLinkButton()
@@ -288,7 +302,7 @@ class FrontendEditingModuleController
         }
         $buttonBar->addButton($presetSplitButtonElement, ButtonBar::BUTTON_POSITION_LEFT, 20);
 
-        // Add width & height input to module docheader
+        // Add width & height inputs to module docheader
         $sizeButtons = new FullyRenderedButton();
         $sizeButtons->setHtmlSource('
             <input class="t3js-frontendediting-input-width" type="number" name="width" min="300" max="9999" value="' . $current['width'] . '">
@@ -362,14 +376,12 @@ class FrontendEditingModuleController
         $icons['mobile'] = $iconFactory->getIcon('actions-device-mobile', Icon::SIZE_SMALL)->render('inline');
         $icons['unidentified'] = $iconFactory->getIcon('actions-device-unidentified', Icon::SIZE_SMALL)->render('inline');
 
-        $current = (isset($this->getBackendUser()->uc['moduleData']['web_view'])) ?
-            $this->getBackendUser()->uc['moduleData']['web_view']['States']['current'] : [];
+        $current = $this->getBackendUser()->uc['moduleData']['web_view']['States']['current'] ?? [];
 
         $current['label'] = ($current['label'] ?? $this->getLanguageService()->sL('LLL:EXT:frontend_editing/Resources/Private/Language/locallang.xlf:custom'));
         $current['width'] = (isset($current['width']) && (int)$current['width'] >= 300 ? (int)$current['width'] : null);
         $current['height'] = (isset($current['height']) && (int)$current['height'] >= 300 ? (int)$current['height'] : null);
-        $custom = (isset($this->getBackendUser()->uc['moduleData']['web_view']['States']['custom']))
-            ? $this->getBackendUser()->uc['moduleData']['web_view']['States']['custom'] : [];
+        $custom = $this->getBackendUser()->uc['moduleData']['web_view']['States']['custom'] ?? [];
         $custom['width'] = (isset($current['custom']) && (int)$current['custom'] >= 300 ? (int)$current['custom'] : 320);
         $custom['height'] = (isset($current['custom']) && (int)$current['custom'] >= 300 ? (int)$current['custom'] : 480);
 

--- a/Resources/Public/JavaScript/FrontendEditing.js
+++ b/Resources/Public/JavaScript/FrontendEditing.js
@@ -150,21 +150,6 @@ define([
 
             // LocalStorage for changes in editors
             storage = new Storage('TYPO3:FrontendEditing');
-
-            // Add spacing so inline actions aren't buried under the toolbar 
-            $iframe.on('load', function () {
-                let $spacer = $iframe.contents().find('.t3-frontend-editing__spacer');
-                if (!$spacer.length) {
-                    $spacer = $('<div/>').addClass('t3-frontend-editing__spacer');
-                    const $body = $iframe.contents().find('body');
-                    $body.prepend($spacer);
-                    $body.find('.t3-frontend-editing__inline-actions').first().each((index, div) => {
-                        if (div.offsetTop < 26) {
-                            $spacer.css({height: '26px', width: '100%'});
-                        }
-                    });
-                }
-            });
         },
 
         /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,6 +8,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['core'][] = 'TYPO3\\CM
 // Exclude the frontend editing from the cHash calculations
 $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'frontend_editing';
 $GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'fe_editing_already_loaded';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['cacheHash']['excludedParameters'][] = 'show_hidden_items';
 
 // Copy configuration array so we can have our own.
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['frontendTcaDatabaseRecord'] =


### PR DESCRIPTION
If the BE user never changed the web_view state then `$this->getBackendUser()->uc['moduleData']['web_view']['States']['current']` is null and triggers PHP8 warning.

Also the former behaviour was to display the website maximized but also wrongly select the "Custom" preset. Now it select the "Maximized" preset.