### PR TITLE
[BUGFIX] Manipulate DOM in a setTimeout on dragStart

### DIFF
--- a/Resources/Public/JavaScript/FrontendEditing.js
+++ b/Resources/Public/JavaScript/FrontendEditing.js
@@ -424,13 +424,15 @@ define([
 
             $('.t3-frontend-editing__right-bar').fadeOut('fast');
 
-            var $iframe = F.iframe();
-            $iframe.contents()
-                .find('.t3-frontend-editing__dropzone[data-tables]')
-                .addClass('t3-frontend-editing__dropzone-hidden');
-            $iframe.contents()
-                .find('body')
-                .addClass('dropzones-enabled');
+            setTimeout(function displayDropZones() {
+                var $iframe = F.iframe();
+                $iframe.contents()
+                    .find('.t3-frontend-editing__dropzone[data-tables]')
+                    .addClass('t3-frontend-editing__dropzone-hidden');
+                $iframe.contents()
+                    .find('body')
+                    .addClass('dropzones-enabled');
+            }, 10);
         },
 
         dragCeEnd: function (ev) {


### PR DESCRIPTION
An old known Chrome bug happens sometimes when the DOM is manipulated on dragStart event and the dragEnd fires immediately. The solution is to add a setTimeout of 10 milliseconds into the handler and manipulate the DOM in that timeout.

Resolves: #680