### PR TITLE
[BUGFIX] Remove obsolete html_entity_decode

### DIFF
--- a/Classes/Service/ContentEditableWrapperService.php
+++ b/Classes/Service/ContentEditableWrapperService.php
@@ -225,7 +225,7 @@ class ContentEditableWrapperService
         $tagBuilder = GeneralUtility::makeInstance(
             TagBuilder::class,
             $this->contentEditableWrapperTagName,
-            html_entity_decode($inlineActionTagBuilder->render() . $content)
+            $inlineActionTagBuilder->render() . $content
         );
 
         $tagBuilder->forceClosingTag(true);


### PR DESCRIPTION
It was added because TYPO3 v9 had some encoding issue. Now it causes some problems, e.g.:
Having a tag in a CE with a data attribute like:
data-focus-point="{"x":0.5,"y":0.5}"
html_entity_decode transforms it to:
data-focus-point="{"x":0.5,"y":0.5}"
so the value of data-focus-point is just "{", causing incorrect JS behavior.